### PR TITLE
Add left margin on brand for mobile devices

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -2,7 +2,7 @@
   <div class="container">
     <div class="navbar-header page-scroll">
       <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-main-collapse"> <i class="fa fa-bars"></i> </button>
-      <a class="navbar-brand" href="{{ site.github_project_name }}/#page-top"> <span>WikiToLearnConf INDIA 2017</span> <br/>
+      <a class="navbar-brand navbar-brand-wtl" href="{{ site.github_project_name }}/#page-top"> <span>WikiToLearnConf INDIA 2017</span> <br/>
         <span class="first-conf">The Indian edition of the WikiToLearnConf</span>
       </a>
     </div>

--- a/_site/about/index.html
+++ b/_site/about/index.html
@@ -56,7 +56,7 @@
   <div class="container">
     <div class="navbar-header page-scroll">
       <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-main-collapse"> <i class="fa fa-bars"></i> </button>
-      <a class="navbar-brand" href="/#page-top"> <span>WikiToLearnConf INDIA 2017</span> <br/>
+      <a class="navbar-brand navbar-brand-wtl" href="/#page-top"> <span>WikiToLearnConf INDIA 2017</span> <br/>
         <span class="first-conf">The Indian edition of the WikiToLearnConf</span>
       </a>
     </div>

--- a/_site/assets/css/override-bootstrap-responsive.css
+++ b/_site/assets/css/override-bootstrap-responsive.css
@@ -59,3 +59,7 @@
   margin-top: 8px;
 }
 
+.navbar-brand-wtl {
+	padding-left: 16px;
+}
+

--- a/_site/code-of-conduct/index.html
+++ b/_site/code-of-conduct/index.html
@@ -56,7 +56,7 @@
   <div class="container">
     <div class="navbar-header page-scroll">
       <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-main-collapse"> <i class="fa fa-bars"></i> </button>
-      <a class="navbar-brand" href="/#page-top"> <span>WikiToLearnConf INDIA 2017</span> <br/>
+      <a class="navbar-brand navbar-brand-wtl" href="/#page-top"> <span>WikiToLearnConf INDIA 2017</span> <br/>
         <span class="first-conf">The Indian edition of the WikiToLearnConf</span>
       </a>
     </div>

--- a/_site/faq/index.html
+++ b/_site/faq/index.html
@@ -56,7 +56,7 @@
   <div class="container">
     <div class="navbar-header page-scroll">
       <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-main-collapse"> <i class="fa fa-bars"></i> </button>
-      <a class="navbar-brand" href="/#page-top"> <span>WikiToLearnConf INDIA 2017</span> <br/>
+      <a class="navbar-brand navbar-brand-wtl" href="/#page-top"> <span>WikiToLearnConf INDIA 2017</span> <br/>
         <span class="first-conf">The Indian edition of the WikiToLearnConf</span>
       </a>
     </div>

--- a/_site/feed.xml
+++ b/_site/feed.xml
@@ -5,8 +5,8 @@
     <description>WikiToLearnConf India is a global event comprising WikiToLearn, Mediawiki and KDE developers from all over India and world.</description>
     <link>https://yourdomain.com/</link>
     <atom:link href="https://yourdomain.com/feed.xml" rel="self" type="application/rss+xml" />
-    <pubDate>Fri, 09 Dec 2016 00:45:53 +0530</pubDate>
-    <lastBuildDate>Fri, 09 Dec 2016 00:45:53 +0530</lastBuildDate>
+    <pubDate>Fri, 09 Dec 2016 01:25:54 +0100</pubDate>
+    <lastBuildDate>Fri, 09 Dec 2016 01:25:54 +0100</lastBuildDate>
     <generator>Jekyll v3.1.6</generator>
     
   </channel>

--- a/_site/index.html
+++ b/_site/index.html
@@ -56,7 +56,7 @@
   <div class="container">
     <div class="navbar-header page-scroll">
       <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-main-collapse"> <i class="fa fa-bars"></i> </button>
-      <a class="navbar-brand" href="/#page-top"> <span>WikiToLearnConf INDIA 2017</span> <br/>
+      <a class="navbar-brand navbar-brand-wtl" href="/#page-top"> <span>WikiToLearnConf INDIA 2017</span> <br/>
         <span class="first-conf">The Indian edition of the WikiToLearnConf</span>
       </a>
     </div>

--- a/_site/travelling-to-jaipur/index.html
+++ b/_site/travelling-to-jaipur/index.html
@@ -56,7 +56,7 @@
   <div class="container">
     <div class="navbar-header page-scroll">
       <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-main-collapse"> <i class="fa fa-bars"></i> </button>
-      <a class="navbar-brand" href="/#page-top"> <span>WikiToLearnConf INDIA 2017</span> <br/>
+      <a class="navbar-brand navbar-brand-wtl" href="/#page-top"> <span>WikiToLearnConf INDIA 2017</span> <br/>
         <span class="first-conf">The Indian edition of the WikiToLearnConf</span>
       </a>
     </div>

--- a/_site/venue/index.html
+++ b/_site/venue/index.html
@@ -56,7 +56,7 @@
   <div class="container">
     <div class="navbar-header page-scroll">
       <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-main-collapse"> <i class="fa fa-bars"></i> </button>
-      <a class="navbar-brand" href="/#page-top"> <span>WikiToLearnConf INDIA 2017</span> <br/>
+      <a class="navbar-brand navbar-brand-wtl" href="/#page-top"> <span>WikiToLearnConf INDIA 2017</span> <br/>
         <span class="first-conf">The Indian edition of the WikiToLearnConf</span>
       </a>
     </div>


### PR DESCRIPTION
Add a `padding-left` on the left side brand on the navbar. This avoid the brand to be sticked on the left without margins on mobile devices